### PR TITLE
Fix backlight conditional compilation order

### DIFF
--- a/Backlight.cpp
+++ b/Backlight.cpp
@@ -1,10 +1,10 @@
-#ifdef BACKLIGHT_LED
-
 #include <FastLED.h>
 #include <EEPROM.h> 
 #include "Config.h"
 #include "Backlight.h"
 #include "Lighting.h"
+
+#ifdef BACKLIGHT
 
 #define BACKLIGHT_NUM_LEDS 2*(BACKLIGHT_WIDTH + BACKLIGHT_HEIGHT)
 


### PR DESCRIPTION
## Problem
Backlight functionality was causing compilation errors when `BACKLIGHT` was defined in `Config.h`

## Solution
- Fixed incorrect macro name from `BACKLIGHT_LED` to `BACKLIGHT` to match Config.h definition
- Moved `#ifdef BACKLIGHT` directive after `#include` statements so the macro can be properly evaluated

## Changes
- Moved conditional compilation check to after Config.h is included
- Fixed macro name mismatch that prevented proper conditional compilation

This resolves compilation errors when enabling backlight functionality.